### PR TITLE
[IMP] replace the deprecated colors= attribute

### DIFF
--- a/openacademy/views/sessions.xml
+++ b/openacademy/views/sessions.xml
@@ -7,7 +7,8 @@
             <field name="model">openacademy.session</field>
             <field name="arch" type="xml">
                 <tree decoration-bf="(taken_seats &gt; 70)"
-                      colors="#0000ff:duration&lt;5;red:duration&gt;15"
+                      decoration-warning="duration &lt; 5"
+                      decoration-danger="duration&gt;15"
                       default_order="start_date">
                     <field name="name"/>
                     <field name="course_id" />


### PR DESCRIPTION
The `colors=` attribute had no effect.
According to the [documentation](https://www.odoo.com/documentation/12.0/reference/views.html#lists), it has been deprecated since version 9.0, and replaced by `decoration-{$name}`.